### PR TITLE
Minor fixes on course

### DIFF
--- a/course/steps/02_component/en.md
+++ b/course/steps/02_component/en.md
@@ -17,7 +17,7 @@ In this course, we'll use Typescript exclusively. If you're not familiar with th
 Since you're already familiar to Store Framework, you know that we use blocks, like `shelf` and `sku-selector`, to create a VTEX IO store. In this step you're going to create a block that is going to be used in your store's home page theme.
 
 ## Setting up our test bot
-It's important for you to have out test bot installed in this course repository so as for us to see your progress, even though it does not contains any tests or evaluation on each step. So as to install it, follow the steps below:
+It's important for you to have our test bot installed in this course repository so we can see your progress, even though it does not contains any tests or evaluation on each step. So as to install it, follow the steps below:
 
 1. Open [our test bot installation page](https://github.com/apps/vtex-course-hub) and click on **Configure**;
 2. Select the **Only selected repositories** option, then click on **Select repositories** and type in `store-block`;

--- a/course/steps/04_countdown-implementation/en.md
+++ b/course/steps/04_countdown-implementation/en.md
@@ -3,6 +3,30 @@
 ## Introduction
 Now we covered the component's basics, it's time to implement the countdown effectively. For that, we need to use a React hook called `useState`.
 
+## The `useState` *hook*
+
+It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state.
+
+>The `useState` returns a pair: the current state value and a function to update it.
+Seeing the example provided the previous step we can understand these concepts: 
+
+```tsx
+const [count, setCount] = useState(0)
+```
+
+In the above code piece, you might observe three things:
+* In the `count` variables, it's possible to get the current state;
+* `setCount` is a function used for updating it;
+* `0` is its initial state;
+
+```tsx
+const [timeRemaining, setTime] = useState<TimeSplit>({
+  hours: '00', 
+  minutes: '00', 
+  seconds: '00'
+})
+```
+
 > It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state. The `useState` returns a pair: the current state value and a function to update it. 
 
 ## Activity

--- a/course/steps/04_countdown-implementation/en.md
+++ b/course/steps/04_countdown-implementation/en.md
@@ -1,44 +1,24 @@
 # Creating the countdown block feature
 
 ## Introduction
-Now we covered the component's basics, it's time to implement the countdown effectively. For that, we need to use a React hook called `useState`. 
+Now we covered the component's basics, it's time to implement the countdown effectively. For that, we need to use a React hook called `useState`.
 
-## The `useState` *hook*
-
-It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state.
-
->The `useState` returns a pair: the current state value and a function to update it.
-
-Seeing the example provided the previous step we can understand these concepts: 
-
-```tsx
-const [count, setCount] = useState(0)
-```
-
-In the above code piece, you might observe three things:
-* In the `count` variables, it's possible to get the current state;
-* `setCount` is a function used for updating it;
-* `0` is its initial state;
-
-```tsx
-const [timeRemaining, setTime] = useState<TimeSplit>({
-  hours: '00', 
-  minutes: '00', 
-  seconds: '00'
-})
-```
+> It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state. The `useState` returns a pair: the current state value and a function to update it. 
 
 ## Activity
-1. We need to import a few functions and types to continue: 
 
-    ```tsx
+1. First, we need to import a few functions and types to continue. Inside the Countdown component, import the following:
+
+    ```ts
     //react/Countdown.tsx
     import React, { useState } from 'react'
     import { TimeSplit } from './typings/global'
-    import { tick } from './utils/time'
+    import { tick, getTwoDaysFromNow } from './utils/time'
     ```
 
-2. Add the state update *hook* (`useState`):
+    > The `getTwoDaysFromNow` function will be used to deal with edge cases. It'll be explained later on in this step.
+
+2. Next step is to add the state update *hook* (`useState`):
 
     ```diff
     //react/Countdown.tsx
@@ -57,14 +37,15 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
     }
     ```
 
-3. Add a default constant `targetDate` for the edge case where the prop is not defined:
+3. After doing that, we'll add a default constant `targetDate` for the edge case where the prop is not defined. We'll use as fallback a date that is defined as two days from the current date, this date is calculated on an util function that was previously imported from the `/utils` folder.
     
     ```typescript
     //react/Countdown.tsx
-    const DEFAULT_TARGET_DATE = (new Date('2020-06-25')).toISOString()
+    const DEFAULT_TARGET_DATE = getTwoDaysFromNow()
     ```
 
-4. Use the `tick` function and the `DEFAULT_TARGET_DATE` constant to make the countdown work:
+4. Now, we need to add the `tick` function and the `DEFAULT_TARGET_DATE` constant to make the countdown work:
+
     ```diff
     //react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
@@ -84,7 +65,8 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
     }
     ```
 
-5. Change the `h1` so that it shows the countdown that we've created. For that, we need to use the `timeRemaining` current state:
+5. At last but not least, change the `h1` so that it shows the countdown that we've created. For that, we need to use the `timeRemaining` current state:
+
     ```diff
     //react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
@@ -104,9 +86,10 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
       ) 
     }
     ```
-    > The countdown *string* formatting is in a `HH:MM:SS` format, made through an `hours`, `minutes` and `seconds` splitting. 
 
-Therefore, with these changes, we'll see a real time update of the countdown! The result in the homepage is this: 
+> The countdown *string* formatting is in a `HH:MM:SS` format, made through an `hours`, `minutes` and `seconds` splitting. 
+
+Therefore, with these changes, we'll see a real-time update of the countdown! The result on the homepage is this: 
 
 ![image](https://user-images.githubusercontent.com/19495917/75474406-b3c06e80-5975-11ea-82ec-89ab27504873.png)
 

--- a/course/steps/04_countdown-implementation/en.md
+++ b/course/steps/04_countdown-implementation/en.md
@@ -8,7 +8,8 @@ Now we covered the component's basics, it's time to implement the countdown effe
 It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state.
 
 >The `useState` returns a pair: the current state value and a function to update it.
-Seeing the example provided the previous step we can understand these concepts: 
+
+Seeing the example provided on the previous step we can understand these concepts:
 
 ```tsx
 const [count, setCount] = useState(0)
@@ -26,8 +27,6 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
   seconds: '00'
 })
 ```
-
-> It is called within the functional component to update and consume the component *state*. The *state* represents the component's current state. The `useState` returns a pair: the current state value and a function to update it. 
 
 ## Activity
 

--- a/course/steps/04_countdown-implementation/en.md
+++ b/course/steps/04_countdown-implementation/en.md
@@ -110,7 +110,7 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
     }
     ```
 
-> The countdown *string* formatting is in a `HH:MM:SS` format, made through an `hours`, `minutes` and `seconds` splitting. 
+    > The countdown *string* formatting is in a `HH:MM:SS` format, made through an `hours`, `minutes` and `seconds` splitting. 
 
 Therefore, with these changes, we'll see a real-time update of the countdown! The result on the homepage is this: 
 

--- a/course/steps/04_countdown-implementation/pt.md
+++ b/course/steps/04_countdown-implementation/pt.md
@@ -8,7 +8,7 @@ Agora que o básico do nosso componente está funcional, é hora de implementar 
 
 É chamado dentro de um componente funcional para atualizar e consumir o *state* de um componente. O *state* simboliza o estado atual de um componente. 
 
->O `useState` retorna um par: o valor do estado atual e uma função para atualizá-lo.
+> O `useState` retorna um par: o valor do estado atual e uma função para atualizá-lo.
 
 Voltando ao exemplo apresentado na etapa anterior, podemos mostrar na prática os conceitos abordados anteriormente. Para lembrar do exemplo, veja o código abaixo:
 

--- a/course/steps/04_countdown-implementation/pt.md
+++ b/course/steps/04_countdown-implementation/pt.md
@@ -1,95 +1,41 @@
-# Criando a funcionalidade do bloco countdown
+# Modifying the countdown block to have configurable styles
 
-## Introdução
-Agora que o básico do nosso componente está funcional, é hora de implementar efetivamente o contador. Para isso, é preciso utilizar um *hook* do React, chamado `useState`;
+## Introduction
 
+Now that we have implemented the `countdown`, how about adding a little customization? In this step, you will learn basic concepts about CSS _handles_ and Tachyons to customize the style of your _app_.
 
-## O *hook* `useState` 
+### CSS Handles
 
-É chamado dentro de um componente funcional para atualizar e consumir o *state* de um componente. O *state* simboliza o estado atual de um componente. 
+CSS _handles_ are used to customize your store's components through CSS classes in the theme code. All settings are defined through the _app_ `vtex.css-handles`, responsible for declaring all the customization points of your block.
 
->O `useState` retorna um par: o valor do estado atual e uma função para atualizá-lo.
+By defining the names of your _handles_ and adding them to their respective HTML elements, it is possible to give the theme's user customization points that allow them to create flexible _layouts_.
 
-Voltando ao exemplo apresentado na etapa anterior, podemos mostrar na prática os conceitos abordados anteriormente. Para lembrar do exemplo, veja o código abaixo:
+### Tachyons
 
-```tsx
-const [count, setCount] = useState(0)
-```
+Tachyons is a _framework_ for functional CSS. Unlike other known _frameworks_, like Bootstrap, it does not have "pre-built" UI components. In fact, its purpose is, precisely, separate the CSS rules into small, reusable parts. This type of strategy is commonly known as _Subatomic Design System_ and, if you are interested, you can find a reference [in this link](https://daneden.me/2018/01/05/subatomic-design-systems/). This strategy makes _frameworks_ like Tachyons very flexible, scalable and fast.
 
-No trecho acima é importante observar três coisas: 
-* Na variável `count`, é possível consumir o estado atual;
-* `setCount` é uma função para atualizá-lo;
-* `0` é o valor do estado inicial
+A lot of the Tachyons' definitions can be changed, so that your store will have a more customized style. To do this, just define a JSON file in the `styles/configs` folder; this information can be found in more detail at: [Customizing styles on VTEX IO](https://developers.vtex.com/docs/vtex-io-documentation-5-customizingstyles).
 
+## Activity
 
-```tsx
-const [timeRemaining, setTime] = useState<TimeSplit>({
-  hours: '00', 
-  minutes: '00', 
-  seconds: '00'
-})
-```
-
-## Atividades
-1. Precisamos importar algumas funções e tipos para continuar:
+1. First, import the `useCssHandles` _hook_. To do so, return to `Countdown.tsx` and do the _import_:
 
     ```tsx
-    //react/Countdown.tsx
-    import React, { useState } from 'react'
-    import { TimeSplit } from './typings/global'
-    import { tick } from './utils/time'
+    // react/Countdown.tsx
+    import { useCssHandles } from "vtex.css-handles"
     ```
 
-2. Adicione o *hook* de atualização de estado (`useState`)
+2. Now, define in a _Array_ all necessary _handles_ (in this case, only `'countdown'` will be used):
+
+    ```tsx
+    // react/Countdown.tsx
+    const CSS_HANDLES = ["countdown"]
+    ```
+
+3. After defining the array, let's use the `useCssHandles` in the component `Countdown` to define the `countdown` _handle_:
 
     ```diff
-    //react/Countdown.tsx
-    const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate }) => {
-    +   const [timeRemaining, setTime] = useState<TimeSplit>({
-    +     hours: '00',
-    +     minutes: '00',
-    +     seconds: '00'
-    +   })
-
-        return (
-          <div>
-            { targetDate }
-          </div>
-        ) 
-    }
-    ```
-    >Observe os detalhes: `timeRemaining` é o estado atual, `setTime` é a função de atualização do estado, `TimeSplit` é o tipo e, por fim, o objeto `{hours: '00', minutes: '00', seconds: '00'}` é o estado inicial do componente.
-
-3. Adicione uma `targetDate` padrão para o caso de não haver um valor inicial definido. Para isso, declare uma constante que será utilizada como padrão:
-    
-    ```typescript
-    //react/Countdown.tsx
-    const DEFAULT_TARGET_DATE = (new Date('2020-06-25')).toISOString()
-    ```
-
-4. Utilize a função `tick` e a constante `DEFAULT_TARGET_DATE`  para fazer o contador:
-    ```diff
-    //react/Countdown.tsx
-    const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
-      const [timeRemaining, setTime] = useState<TimeSplit>({
-        hours: '00',
-        minutes: '00',
-        seconds: '00'
-    })
-
-    + tick(targetDate, setTime)
-
-      return (
-        <div>
-          { targetDate }
-        </div>
-      ) 
-    }
-    ```
-
-5. Altere o `h1` para que ele exiba o contador que criamos. Para isso, precisamos utilizar o estado atual `timeRemaining`:
-    ```diff
-    //react/Countdown.tsx
+    // react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
       const [timeRemaining, setTime] = useState<TimeSplit>({
         hours: '00',
@@ -97,20 +43,48 @@ const [timeRemaining, setTime] = useState<TimeSplit>({
         seconds: '00'
       })
 
+    + const handles = useCssHandles(CSS_HANDLES)
+
       tick(targetDate, setTime)
 
       return (
-        <div>   
-    -     <h1>{ targetDate }</h1>
-    +     <h1>{ `${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}` }</h1>
+        <div>
+          <h1>
+            { `${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}` }
+          </h1>
         </div>
-      ) 
+      )
     }
     ```
-    > A formatação da *string* do contador está no formato `HH:MM:SS`, feita através do *split* em `hours`, `minutes` e `seconds`.
 
-Assim, com essas alterações, veremos a atualização em tempo real do contador! O resultado na *home* é esse:
+4. At last, it is needed to use the _handle_ in the component to see the customization. For this, use the prop `className` with the classes to be used and the Tachyons classes, for global styles.
 
-![image](https://user-images.githubusercontent.com/19495917/75474406-b3c06e80-5975-11ea-82ec-89ab27504873.png)
+    ```diff
+    // react/Countdown.tsx
+    import React from 'react'
+    ...
 
-<img src="https://user-images.githubusercontent.com/19495917/75474511-e0748600-5975-11ea-825d-7e9a20f95362.gif" width="500" height="320"/>
+    const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
+      const [timeRemaining, setTime] = useState<TimeSplit>({
+        hours: '00',
+        minutes: '00',
+        seconds: '00'
+      })
+
+      const handles = useCssHandles(CSS_HANDLES)
+
+      tick(targetDate, setTime)
+
+      return (
+    +   <div className={`${handles.countdown} c-muted-1 db tc`}>
+          {`${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}`}
+        </div>
+      )
+    }
+    ```
+
+Let's see the result?
+
+![image](https://user-images.githubusercontent.com/19495917/75475280-457cab80-5977-11ea-938e-d3c2b532e891.png)
+
+<img src="https://user-images.githubusercontent.com/19495917/75475388-7a88fe00-5977-11ea-9d35-c13482f1e61c.gif" width="500" height="400"/>

--- a/course/steps/04_countdown-implementation/pt.md
+++ b/course/steps/04_countdown-implementation/pt.md
@@ -1,69 +1,97 @@
-# Modifying the countdown block to have configurable styles
+# Criando a funcionalidade do bloco countdown
 
-## Introduction
+## Introdução
+Agora que o básico do nosso componente está funcional, é hora de implementar efetivamente o contador. Para isso, é preciso utilizar um *hook* do React, chamado `useState`;
 
-Now that we have implemented the `countdown`, how about adding a little customization? In this step, you will learn basic concepts about CSS _handles_ and Tachyons to customize the style of your _app_.
 
-### CSS Handles
+## O *hook* `useState` 
 
-CSS _handles_ are used to customize your store's components through CSS classes in the theme code. All settings are defined through the _app_ `vtex.css-handles`, responsible for declaring all the customization points of your block.
+É chamado dentro de um componente funcional para atualizar e consumir o *state* de um componente. O *state* simboliza o estado atual de um componente. 
 
-By defining the names of your _handles_ and adding them to their respective HTML elements, it is possible to give the theme's user customization points that allow them to create flexible _layouts_.
+>O `useState` retorna um par: o valor do estado atual e uma função para atualizá-lo.
 
-### Tachyons
+Voltando ao exemplo apresentado na etapa anterior, podemos mostrar na prática os conceitos abordados anteriormente. Para lembrar do exemplo, veja o código abaixo:
 
-Tachyons is a _framework_ for functional CSS. Unlike other known _frameworks_, like Bootstrap, it does not have "pre-built" UI components. In fact, its purpose is, precisely, separate the CSS rules into small, reusable parts. This type of strategy is commonly known as _Subatomic Design System_ and, if you are interested, you can find a reference [in this link](https://daneden.me/2018/01/05/subatomic-design-systems/). This strategy makes _frameworks_ like Tachyons very flexible, scalable and fast.
+```tsx
+const [count, setCount] = useState(0)
+```
 
-A lot of the Tachyons' definitions can be changed, so that your store will have a more customized style. To do this, just define a JSON file in the `styles/configs` folder; this information can be found in more detail at: [Customizing styles on VTEX IO](https://developers.vtex.com/docs/vtex-io-documentation-5-customizingstyles).
+No trecho acima é importante observar três coisas: 
+* Na variável `count`, é possível consumir o estado atual;
+* `setCount` é uma função para atualizá-lo;
+* `0` é o valor do estado inicial
 
-## Activity
 
-1. First, import the `useCssHandles` _hook_. To do so, return to `Countdown.tsx` and do the _import_:
+```tsx
+const [timeRemaining, setTime] = useState<TimeSplit>({
+  hours: '00', 
+  minutes: '00', 
+  seconds: '00'
+})
+```
+
+## Atividade
+1. Precisamos importar algumas funções e tipos para continuar:
 
     ```tsx
-    // react/Countdown.tsx
-    import { useCssHandles } from "vtex.css-handles"
+    //react/Countdown.tsx
+    import React, { useState } from 'react'
+    import { TimeSplit } from './typings/global'
+    import { tick, getTwoDaysFromNow } from './utils/time'
     ```
 
-2. Now, define in a _Array_ all necessary _handles_ (in this case, only `'countdown'` will be used):
+    > A função `getTwoDaysFromNow` será utilizada para tratar condições de borda. Será explicado mais tarde neste passo.
 
-    ```tsx
-    // react/Countdown.tsx
-    const CSS_HANDLES = ["countdown"]
-    ```
-
-3. After defining the array, let's use the `useCssHandles` in the component `Countdown` to define the `countdown` _handle_:
+2. Adicione o *hook* de atualização de estado (`useState`)
 
     ```diff
-    // react/Countdown.tsx
+    //react/Countdown.tsx
+    const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate }) => {
+    +   const [timeRemaining, setTime] = useState<TimeSplit>({
+    +     hours: '00',
+    +     minutes: '00',
+    +     seconds: '00'
+    +   })
+
+        return (
+          <div>
+            { targetDate }
+          </div>
+        ) 
+    }
+    ```
+    >Observe os detalhes: `timeRemaining` é o estado atual, `setTime` é a função de atualização do estado, `TimeSplit` é o tipo e, por fim, o objeto `{hours: '00', minutes: '00', seconds: '00'}` é o estado inicial do componente.
+
+3. Adicione uma `targetDate` padrão para o caso de não haver um valor inicial definido. Vamos utilizar para isto uma data que é definida como dois dias a partir da data atual e ela será calculada em uma função utilitária que foi previamente importada da pasta `/utils`:
+    
+    ```typescript
+    //react/Countdown.tsx
+    const DEFAULT_TARGET_DATE = getTwoDaysFromNow()
+    ```
+
+4. Utilize a função `tick` e a constante `DEFAULT_TARGET_DATE`  para fazer o contador:
+    ```diff
+    //react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
       const [timeRemaining, setTime] = useState<TimeSplit>({
         hours: '00',
         minutes: '00',
         seconds: '00'
-      })
+    })
 
-    + const handles = useCssHandles(CSS_HANDLES)
-
-      tick(targetDate, setTime)
+    + tick(targetDate, setTime)
 
       return (
         <div>
-          <h1>
-            { `${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}` }
-          </h1>
+          { targetDate }
         </div>
-      )
+      ) 
     }
     ```
 
-4. At last, it is needed to use the _handle_ in the component to see the customization. For this, use the prop `className` with the classes to be used and the Tachyons classes, for global styles.
-
+5. Altere o `h1` para que ele exiba o contador que criamos. Para isso, precisamos utilizar o estado atual `timeRemaining`:
     ```diff
-    // react/Countdown.tsx
-    import React from 'react'
-    ...
-
+    //react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
       const [timeRemaining, setTime] = useState<TimeSplit>({
         hours: '00',
@@ -71,20 +99,20 @@ A lot of the Tachyons' definitions can be changed, so that your store will have 
         seconds: '00'
       })
 
-      const handles = useCssHandles(CSS_HANDLES)
-
       tick(targetDate, setTime)
 
       return (
-    +   <div className={`${handles.countdown} c-muted-1 db tc`}>
-          {`${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}`}
+        <div>   
+    -     <h1>{ targetDate }</h1>
+    +     <h1>{ `${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}` }</h1>
         </div>
-      )
+      ) 
     }
     ```
+    > A formatação da *string* do contador está no formato `HH:MM:SS`, feita através do *split* em `hours`, `minutes` e `seconds`.
 
-Let's see the result?
+Assim, com essas alterações, veremos a atualização em tempo real do contador! O resultado na *home* é esse:
 
-![image](https://user-images.githubusercontent.com/19495917/75475280-457cab80-5977-11ea-938e-d3c2b532e891.png)
+![image](https://user-images.githubusercontent.com/19495917/75474406-b3c06e80-5975-11ea-82ec-89ab27504873.png)
 
-<img src="https://user-images.githubusercontent.com/19495917/75475388-7a88fe00-5977-11ea-9d35-c13482f1e61c.gif" width="500" height="400"/>
+<img src="https://user-images.githubusercontent.com/19495917/75474511-e0748600-5975-11ea-825d-7e9a20f95362.gif" width="500" height="320"/>

--- a/course/steps/05_css-handles/en.md
+++ b/course/steps/05_css-handles/en.md
@@ -76,7 +76,7 @@ A lot of the Tachyons' definitions can be changed, so that your store will have 
      tick(targetDate, setTime)
 
      return (
-   +   <div className={`${handles.countdown} t-heading-2 fw3 w-100 c-muted-1 db tc`}>
+   +   <div className={`${handles.countdown} c-muted-1 db tc`}>
          {`${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}`}
        </div>
      )

--- a/course/steps/05_css-handles/pt.md
+++ b/course/steps/05_css-handles/pt.md
@@ -3,33 +3,34 @@
 ## Introdução
 Agora que já implementamos o `countdown`, que tal adicionar um pouco de customização? Nessa etapa, você irá aprender conceitos básicos a respeito de CSS *handles* e Tachyons para, em seguida, customizar o estilo da sua *app*.
 
-## CSS Handles
+### CSS Handles
 
 Os *handles* de CSS são utilizados para customizar os componentes da sua loja através de classes de CSS no código do tema. Todas essas configurações são definidas através da *app* `vtex.css-handles`, responsável por declarar todos os pontos de customização do seu bloco.
 
 Definindo os nomes dos seus *handles* e adicionando aos seus respectivos elementos HTML, é possível entregar ao usuário do tema pontos de customização que que permitam criar *layouts* flexíveis. 
 
-## Tachyons
+### Tachyons
 O Tachyons é um *framework* para CSS funcional. Diferentemente de outros *frameworks* conhecidos, como o Bootstrap, ele não apresenta componentes UI "pré-buildados". Na verdade, seu objetivo é justamente separar as regras de CSS em partes pequenas e reutilizáveis. Esse tipo de estratégia é comumente conhecida como *Subatomic Design System* e, caso você tenha interesse, pode encontrar uma referência [neste link](https://daneden.me/2018/01/05/subatomic-design-systems/). Essa estratégia torna *frameworks* como o Tachyons muito flexíveis, escaláveis e rápidos.
 
-Grande parte das definições de Tachyons podem ser alteradas, de forma que sua loja passe a ter um estilo mais customizado. Para isso, basta definir um arquivo JSON na pasta `styles/configs`; essas informações podem ser encontradas de forma mais detalhada em: [Build a store using VTEX IO - Customizing styles](https://help.vtex.com/tracks/build-a-store-using-vtex-io--5qJr8BIQXAKec9CpBWrTNv/6L2qQHU5kwbmTSiYl4MCuD). 
+Grande parte das definições de Tachyons podem ser alteradas, de forma que sua loja passe a ter um estilo mais customizado. Para isso, basta definir um arquivo JSON na pasta `styles/configs`; essas informações podem ser encontradas de forma mais detalhada em: [Customizing styles on VTEX IO](https://developers.vtex.com/docs/vtex-io-documentation-5-customizingstyles). 
 
 ## Atividade
-1. Importe o *hook* `useCssHandles`. Para isso, volte ao `Countdown.tsx` e faça o *import*:
+
+1. Primeiro, importe o *hook* `useCssHandles`. Para isso, volte ao `Countdown.tsx` e faça o *import*:
 
     ```tsx
     // react/Countdown.tsx
     import { useCssHandles } from 'vtex.css-handles'
     ```
 
-2. Além disso, defina em um *Array* todos os *handles* que serão necessários (neste caso, será utilizado apenas `'countdown'`):
+2. Feito isso, defina em um *Array* todos os *handles* que serão necessários (neste caso, será utilizado apenas `'countdown'`):
 
     ```tsx
     // react/Countdown.tsx
     const CSS_HANDLES = ['countdown']
     ```
 
-3. Utilize o `useCssHandles` no componente `Countdown` para definir o *handle* do `countdown`:
+3. Após a definição do _array_, utilize o `useCssHandles` no componente `Countdown` para definir o *handle* do `countdown`:
 
     ```diff
     // react/Countdown.tsx
@@ -55,11 +56,12 @@ Grande parte das definições de Tachyons podem ser alteradas, de forma que sua 
     ```
 
 4. Por fim, é preciso utilizar o *handle* no componente a fim de ver a customização. Para isso, é necessário utilizar a prop `className` com as classes a serem utilizadas e as classes de Tachyons, para os estilos globais.
+
     ```diff
     // react/Countdown.tsx
     import React from 'react'
     ...
-    
+
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({ targetDate = DEFAULT_TARGET_DATE }) => {
       const [timeRemaining, setTime] = useState<TimeSplit>({
         hours: '00',
@@ -72,7 +74,7 @@ Grande parte das definições de Tachyons podem ser alteradas, de forma que sua 
       tick(targetDate, setTime)
 
       return (
-    +   <div className={`${handles.countdown} t-heading-2 fw3 w-100 c-muted-1 db tc`}>
+    +   <div className={`${handles.countdown} c-muted-1 db tc`}>
           {`${timeRemaining.hours}:${timeRemaining.minutes}:${timeRemaining.seconds}`}
         </div>
       )

--- a/course/steps/07_separating-title/en.md
+++ b/course/steps/07_separating-title/en.md
@@ -22,30 +22,29 @@ When defining an _app_ in the interface, the `component` property is responsible
 }
 ```
 
-## Activity
-
-In this activity, the title will be separated and added to the store below the countdown.
+Now, you are going to separate the title from the countdown block and add it to the store below the countdown.
 
 ### Altering the `Countdown` component
 
-1. Remove the _imports_, the `title` from the interface and change the CSS _handles_ const, `CSS_HANDLES`:
-   ```diff
-   //react/Countdown.tsx
-   import React, { useState } from 'react'
-   import { TimeSplit } from './typings/global'
-   import { tick } from './utils/time'
-   import { useCssHandles } from 'vtex.css-handles'
-   -import { FormattedMessage } from 'react-intl'
+1. First, remove the _imports_, the `title` from the interface and change the CSS _handles_ const, `CSS_HANDLES`:
 
-   interface CountdownProps {
-     targetDate: string,
-   -  title: string
-   }
+    ```diff
+    //react/Countdown.tsx
+    import React, { useState } from 'react'
+    import { TimeSplit } from './typings/global'
+    import { tick, getTwoDaysFromNow } from './utils/time'
+    import { useCssHandles } from 'vtex.css-handles'
+    -import { FormattedMessage } from 'react-intl'
 
-   const DEFAULT_TARGET_DATE = (new Date('2020-03-02')).toISOString()
-   -const CSS_HANDLES = ['container', 'countdown', 'title']
-   +const CSS_HANDLES = ['countdown']
-   ```
+    interface CountdownProps {
+      targetDate: string,
+    -  title: string
+    }
+
+    const DEFAULT_TARGET_DATE = getTwoDaysFromNow()
+    -const CSS_HANDLES = ['container', 'countdown', 'title']
+    +const CSS_HANDLES = ['countdown']
+    ```
 
 2. Now, in the component itself, remove the `title` as a _prop_ given and also the title text constant, which changes what is being rendered:
 
@@ -79,93 +78,91 @@ In this activity, the title will be separated and added to the store below the c
           </div>
     -   </div>
       )
-   }
-   ```
+    }
+    ```
 
 3. At last, remove the title from the _schema_:
 
-   ```diff
-   //react/Countdown.tsx
-   Countdown.schema = {
-     title: 'editor.countdown.title',
-     description: 'editor.countdown.description',
-     type: 'object',
-     properties: {
-   -   title: {
-   -     title: 'I am a title',
-   -     type: 'string',
-   -     default: null,
-   -   },
-       targetDate: {
-         title: 'Final date',
-         description: 'Final date used in the countdown',
-         type: 'string',
-         default: null,
-       },
-     },
-   }
-   ```
+    ```diff
+    //react/Countdown.tsx
+    Countdown.schema = {
+      title: 'editor.countdown.title',
+      description: 'editor.countdown.description',
+      type: 'object',
+      properties: {
+    -   title: {
+    -     title: 'I am a title',
+    -     type: 'string',
+    -     default: null,
+    -   },
+        targetDate: {
+          title: 'Final date',
+          description: 'Final date used in the countdown',
+          type: 'string',
+          default: null,
+        },
+      },
+    }
+    ```
 
 ### Creating a new component
 
-1. Create a new file in the `/react` directory, named `Title.tsx`, it will be the new title component. In it, some _imports_ are needed. The basic structure of the code is very similar to the `Countdown` component's.
+1. Create a new file in the `/react` directory, named `Title.tsx`, it will be the new title component. In it, some _imports_ are needed. The basic structure of the code is very similar to the `Countdown` component's. Afer doing that, add the _imports_ needed and the CSS _handles_ constant:
 
-2. Add the _imports_ needed and the CSS _handles_ constant:
+    ```tsx
+    //react/Title.tsx
+    import React from "react"
+    import { FormattedMessage } from "react-intl"
+    import { useCssHandles } from "vtex.css-handles"
 
-   ```tsx
-   //react/Title.tsx
-   import React from "react"
-   import { FormattedMessage } from "react-intl"
-   import { useCssHandles } from "vtex.css-handles"
+    const CSS_HANDLES = ["title"] as const
+    ```
 
-   const CSS_HANDLES = ["title"] as const
-   ```
+2. Now, it's necessary to change the component's function:
 
-3. Change the component's function:
+    ```tsx
+    //react/Title.tsx
+    const Title: StorefrontFunctionComponent<TitleProps> = ({ title }) => {
+      const handles = useCssHandles(CSS_HANDLES)
+      const titleText = title || <FormattedMessage id="countdown.title" />
 
-   ```tsx
-   //react/Title.tsx
-   const Title: StorefrontFunctionComponent<TitleProps> = ({ title }) => {
-     const handles = useCssHandles(CSS_HANDLES)
-     const titleText = title || <FormattedMessage id="countdown.title" />
+      return (
+        <div
+          className={`${handles.title} t-heading-2 fw3 w-100 c-muted-1 db tc`}
+        >
+          {titleText}
+        </div>
+      )
+    }
+    ```
 
-     return (
-       <div
-         className={`${handles.title} t-heading-2 fw3 w-100 c-muted-1 db tc`}
-       >
-         {titleText}
-       </div>
-     )
-   }
-   ```
+3. At last, add the interface, the _schema_ and the _export_:
 
-4. Add the interface, the _schema_ and the _export_:
+    ```tsx
+    //react/Title.tsx
+    interface TitleProps {
+      title: string
+    }
 
-   ```tsx
-   //react/Title.tsx
-   interface TitleProps {
-     title: string
-   }
+    Title.schema = {
+      title: "editor.countdown-title.title",
+      description: "editor.countdown-title.description",
+      type: "object",
+      properties: {
+        title: {
+          title: "I am a title",
+          type: "string",
+          default: null,
+        },
+      },
+    }
 
-   Title.schema = {
-     title: "editor.countdown-title.title",
-     description: "editor.countdown-title.description",
-     type: "object",
-     properties: {
-       title: {
-         title: "I am a title",
-         type: "string",
-         default: null,
-       },
-     },
-   }
-
-   export default Title
-   ```
+    export default Title
+    ```
 
 ### Changing the `interfaces.json` file
 
-By now, there are two components in the _app_: the title and the countdown. However, it is necessary to change the `interfaces.json` file, which is in `store` folder. It is needed to declare each one separately. At first, our interface only contained the `Countdown`. It is needed to add the other component:
+By now, there are two components in the _app_: the title and the countdown. However, it is necessary to change the `interfaces.json` file, which is in the `store` folder. It is needed to declare each one separately. At first, our interface only contained the `Countdown`. It is needed to add the other component:
 
 ```diff
 {
@@ -180,7 +177,7 @@ By now, there are two components in the _app_: the title and the countdown. Howe
 
 ### Adding internationalization
 
-It is also needed to add to the _Messages_ the translations whose keys are the _strings_ of the _schema_ that we included in the `Title.tsx` file above. As seen in the _Messages_ step, go to the `/messages` folder and add the necessary translations to each file (`pt.json`, `es.json` and `en.json`). Below is an example for the case of the `en.json` file:
+It is also needed to add to the _Messages_ the translations whose keys are the _strings_ of the _schema_ that we included in the `Title.tsx` file above. As seen in the _Messages_ step, go to the `/messages` folder, and add the necessary translations to each file (`pt.json`, `es.json` and `en.json`). Below is an example for the case of the `en.json` file:
 
 ```diff
  {

--- a/course/steps/07_separating-title/en.md
+++ b/course/steps/07_separating-title/en.md
@@ -22,6 +22,8 @@ When defining an _app_ in the interface, the `component` property is responsible
 }
 ```
 
+## Activity
+
 Now, you are going to separate the title from the countdown block and add it to the store below the countdown.
 
 ### Altering the `Countdown` component

--- a/course/steps/07_separating-title/pt.md
+++ b/course/steps/07_separating-title/pt.md
@@ -19,6 +19,8 @@ Exemplo de `interfaces.json`:
 }
 ```
 
+## Atividade
+
 Agora, você irá separar o título do bloco do contador e adicioná-lo à nossa loja embaixo do contador.
 
 ### Alterando o componente `Countdown`

--- a/course/steps/07_separating-title/pt.md
+++ b/course/steps/07_separating-title/pt.md
@@ -2,6 +2,7 @@
 
 ## Introdução
 Nessa etapa, a *app* tem dois elementos principais: o título e o contador. Porém, para obter uma maior flexibilidade de posicionamento e customização, é interessante que sejam separadas em dois blocos distintos. Para isso, é preciso apresentar brevemente o conceito de interfaces para, em seguida, ser desenvolvido um novo componente `Title`. Um exemplo de customização em termos de posicionamento, que será abordada nessa etapa, é:
+
 > E se eu quisesse que o título estivesse embaixo ou ao lado do contador?
 
 ## Interface
@@ -18,30 +19,32 @@ Exemplo de `interfaces.json`:
 }
 ```
 
-## Atividade
-Nessa atividade, será separado o título e adicionado à nossa loja embaixo do contador.
+Agora, você irá separar o título do bloco do contador e adicioná-lo à nossa loja embaixo do contador.
 
 ### Alterando o componente `Countdown`
 
-1. Remova os *imports*, o `title` da interface e altere a constante do CSS *handles*:
+1. Em primeiro lugar, remova os *imports*, o `title` da interface e altere a constante do CSS *handles*:
+
     ```diff
     //react/Countdown.tsx
     import React, { useState } from 'react'
     import { TimeSplit } from './typings/global'
-    import { tick } from './utils/time'
+    import { tick, getTwoDaysFromNow } from './utils/time'
     import { useCssHandles } from 'vtex.css-handles'
     -import { FormattedMessage } from 'react-intl'
 
     interface CountdownProps {
       targetDate: string,
-   -  title: string
+    -  title: string
     }
 
-    const DEFAULT_TARGET_DATE = (new Date('2020-03-02')).toISOString()
+    const DEFAULT_TARGET_DATE = getTwoDaysFromNow()
     -const CSS_HANDLES = ['container', 'countdown', 'title']
     +const CSS_HANDLES = ['countdown']
     ```
+
 2. Agora, no componente React em si, é preciso retirar o `title` como *prop* recebida e a constante do texto do título, além de alterar o que é renderizado:
+
     ```diff
     //react/Countdown.tsx
     const Countdown: StorefrontFunctionComponent<CountdownProps> = ({
@@ -72,9 +75,11 @@ Nessa atividade, será separado o título e adicionado à nossa loja embaixo do 
           </div>
     -   </div>
       )
-   }
-   ```
+    }
+    ```
+
 3. Por fim, retire o título do *schema*:
+
     ```diff
     //react/Countdown.tsx
     Countdown.schema = {
@@ -99,9 +104,8 @@ Nessa atividade, será separado o título e adicionado à nossa loja embaixo do 
 
 ### Criando um novo componente
 
-1. Crie um novo arquivo dentro da pasta `/react`, chamado `Title.tsx`, ele será o novo componente do título. Nele, alguns *imports* precisam ser feitos. A estrutura básica do código é muito similar a do componente `Countdown`.
+1. Crie um novo arquivo dentro da pasta `/react`, chamado `Title.tsx`, ele será o novo componente do título. Nele, alguns *imports* precisam ser feitos. A estrutura básica do código é muito similar a do componente `Countdown`. Feito isso, adicione os *imports* necessários e a constante do CSS *handles*:
 
-2. Adicione os *imports* necessários e a constante do CSS *handles*:
     ```tsx
     //react/Title.tsx
     import React from 'react'
@@ -110,7 +114,8 @@ Nessa atividade, será separado o título e adicionado à nossa loja embaixo do 
 
     const CSS_HANDLES = ['title'] as const
     ```
-3. Altere a função do componente:
+2. Agora, é necessário alterar a função do componente:
+
     ```tsx
     //react/Title.tsx
     const Title: StorefrontFunctionComponent<TitleProps> = ({title}) => {
@@ -124,7 +129,9 @@ Nessa atividade, será separado o título e adicionado à nossa loja embaixo do 
       )
     }
     ```
-4. Adicione a interface, o *schema* e o *export*:
+
+3. Por fim, adicione a interface, o *schema* e o *export*:
+
     ```tsx
     //react/Title.tsx
     interface TitleProps {

--- a/course/steps/08_react-apollo/en.md
+++ b/course/steps/08_react-apollo/en.md
@@ -14,7 +14,7 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
 
    ```diff
        "product-gifts",
-   +	"countdown",
+   +	 "countdown",
        "flex-layout.row#buy-button",
        "availability-subscriber",
    ```
@@ -59,10 +59,10 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
 4. After that, define the query using the `productReleaseDate` imported and the `useQuery` hook, you can find the product data in `useProduct` hook. Since they are [hooks](https://reactjs.org/docs/hooks-intro.html), they only work inside react functional components. 
 
     ```diff
-    + const { product: { linkText } } = useProduct()
+    + const { product } = useProduct()
     + const { data, loading, error } = useQuery(productReleaseDate, {
     +   variables: {
-    +     slug: linkText
+    +     slug: product?.linkText
     +   },
     +   ssr: false
     + })
@@ -73,7 +73,7 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
 5. Now that we're using our block in pages that have the product context, it's important to test if this context exists. To do that, let's add the following code block:
 
     ```tsx
-    if (!linkText) {
+    if (!product) {
       return (
         <div>
           <span>There is no product context.</span>

--- a/course/steps/08_react-apollo/en.md
+++ b/course/steps/08_react-apollo/en.md
@@ -42,7 +42,7 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
     "vtex.product-context": "0.x"
     ```
 
-3. Now, it is necessary to import the `useQuery` hooks, to make the _query_ that will return the data we described, and `useProduct`, to give us information about the current product slug. In addition, it is also necessary to import the _query_ defined previously, which is found in the file `productReleaseDate.graphql`. It is also important to notice that the prop `targetDate` will no longer be necessary.
+3. Now, it is necessary to import the `useQuery` hooks, to make the _query_ that will return the data we described, and `useProduct`, to give us information about the current product slug. In addition, it is also necessary to import the _query_ defined previously, which is found in the file `productReleaseDate.graphql`.
 
     ```diff
     // react/Countdown.tsx
@@ -54,7 +54,10 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
 
     +import productReleaseDate from './queries/productReleaseDate.graphql'
     ```
-    > It is important to higlight that there is the possibility of your IDE showing an error while importing `product-context`.
+    > It is important to higlight that there is the possibility of your IDE showing an error while importing `product-context`. 
+    
+    > The prop `targetDate` and the definition of `DEFAULT_TARGET_DATE` will no longer be necessary, so you can remove them and adjust the imports, in case of not using some functions anymore.
+
 
 4. After that, define the query using the `productReleaseDate` imported and the `useQuery` hook, you can find the product data in `useProduct` hook. Since they are [hooks](https://reactjs.org/docs/hooks-intro.html), they only work inside react functional components. 
 
@@ -118,7 +121,7 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
 
     ```diff
     -tick(targetDate, setTime)
-    +tick(data?.product?.releaseDate || DEFAULT_TARGET_DATE, setTime)
+    +tick(data?.product?.releaseDate, setTime)
     ```
 
 Result using the _Red Front-Loading Washer_ product:

--- a/course/steps/08_react-apollo/en.md
+++ b/course/steps/08_react-apollo/en.md
@@ -4,7 +4,7 @@
 
 Now we will learn how to retrieve data from the _backend_ and display it in the interface. VTEX IO uses [GraphQL](https://graphql.org/) as a language/technology for data transfer, which makes programming our components quite simple. We will modify our Countdown component to search for the _targetDate_ of the **`releaseDate` field of a VTEX product**. To perform GraphQL queries in React, the **Apollo Client** is used, a state management lib that facilitates the integration of a GraphQL API with the _front-end_ application.
 
-The **Apollo Client** lib offers native integration with React, through _hooks_. Thus, making a _query_ means using a _hook_ that will not only perform the _queries_ and _fetch_ the data, but will also provide caching and updating the UI state. This integration, called `react-apollo` is already declared in `package.json`.
+The **Apollo Client** lib offers native integration with React, through _hooks_. Thus, making a _query_ means using a _hook_ that will not only perform the _queries_ and _fetch_ the data but will also provide caching and updating the UI state. This integration, called `react-apollo` is already declared in `package.json`.
 
 ## Preparation
 
@@ -19,32 +19,30 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
        "availability-subscriber",
    ```
 
-2. Run `vtex link` on your theme again (if the process is not already running).
-
-3. Done, now our block is on the product page. Access any of these pages and see the rendered `Countdown` component.
+2. Now, run `vtex link` on your theme again (if the process is not already running). It's done! Now our block is on the product page. Access any of these pages and see the rendered `Countdown` component.
 
 ## Release Date Query
 
-1.  Create a folder `react/queries` and add a `productReleaseDate.graphql` file to it that will contain the _query_ to be made. In particular, this _query_ will receive a term, which will be **the product slug to be retrieved at the launch date**. It will call the _resolver_ `product`, already available through the`vtex.search-graphql` app, and we will retrieve only the field we need.
+1. First, create a folder `react/queries` and add a `productReleaseDate.graphql` file to it that will contain the _query_ to be made. In particular, this _query_ will receive a term, which will be **the product slug to be retrieved at the launch date**. It will call the _resolver_ `product`, already available through the`vtex.search-graphql` app, and we will retrieve only the field we need.
 
-    ```
+    ```graphql
     query productReleaseDate($slug: String){
-    	  product(slug: $slug) {
-    		    releaseDate
-    	  }
+        product(slug: $slug) {
+            releaseDate
+        }
     }
     ```
 
     > Note that the query will need the _slug_ of the product we are looking for. To do so, **retrieve this information of the VTEX Product context**.
 
-2.  To use this query, it is necessary **to add the `vtex.search-graphql` app as a dependency on your app**. We will also need to use the `useProduct` hook, exported by the `vtex.product-context` app, to retrieve the product slug that is loaded on the page. To do this, in your app's `manifest.json`, add in dependencies:
+2. To use this query, it is necessary **to add the `vtex.search-graphql` app as a dependency on your app**. We will also need to use the `useProduct` hook, exported by the `vtex.product-context` the app, to retrieve the product slug that is loaded on the page. To do this, in your app's `manifest.json`, add in dependencies:
 
     ```
     "vtex.search-graphql": "0.x",
     "vtex.product-context": "0.x"
     ```
 
-3.  Now, it is necessary to import the `useQuery` hooks, to make the _query_ that will return the data we described, and `useProduct`, to give us information about the current product slug. In addition, it is also necessary to import the _query_ defined previously, which is found in the file `productReleaseDate.graphql`. It is also important to notice that the prop `targetDate` will no longer be necessary.
+3. Now, it is necessary to import the `useQuery` hooks, to make the _query_ that will return the data we described, and `useProduct`, to give us information about the current product slug. In addition, it is also necessary to import the _query_ defined previously, which is found in the file `productReleaseDate.graphql`. It is also important to notice that the prop `targetDate` will no longer be necessary.
 
     ```diff
     // react/Countdown.tsx
@@ -58,21 +56,34 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
     ```
     > It is important to higlight that there is the possibility of your IDE showing an error while importing `product-context`.
 
-4.  Define the query using the `productReleaseDate` imported and the `useQuery` hook, you can find the product data in `useProduct` hook. Since they are (hooks)[https://reactjs.org/docs/hooks-intro.html], they only work inside react functional components. 
+4. After that, define the query using the `productReleaseDate` imported and the `useQuery` hook, you can find the product data in `useProduct` hook. Since they are [hooks](https://reactjs.org/docs/hooks-intro.html), they only work inside react functional components. 
 
-      ```diff
-      + const { product: { linkText } } = useProduct()
-      + const { data, loading, error } = useQuery(productReleaseDate, {
-      +   variables: {
-      +     slug: linkText
-      +   },
-      +   ssr: false
-      + })
-      ```
+    ```diff
+    + const { product: { linkText } } = useProduct()
+    + const { data, loading, error } = useQuery(productReleaseDate, {
+    +   variables: {
+    +     slug: linkText
+    +   },
+    +   ssr: false
+    + })
+    ```
 
     > `linkText` will be the same as `'red-front-loading-washer'`, for example, when your component is rendered in this product's page.
 
-    Besides, it is important to deal with the cases in which there is no data fetched when using useQuery and before returning the main component: *loading* and *error* In those cases, it is possible to return a span in the countdown component, such as the example below:
+5. Now that we're using our block in pages that have the product context, it's important to test if this context exists. To do that, let's add the following code block:
+
+    ```tsx
+    if (!linkText) {
+      return (
+        <div>
+          <span>There is no product context.</span>
+        </div>
+      )
+    }
+    ```
+
+6. Besides, it is important to deal with the cases in which there is no data fetched when using `useQuery` and before returning the main component: *loading* and *error* In those cases, it is possible to return a span in the countdown component, such as the example below:
+
     ```tsx
     if (loading) {
       return (
@@ -90,20 +101,20 @@ The **Apollo Client** lib offers native integration with React, through _hooks_.
     }
     ```
 
-5.  After sending the changes, access a product page and note that the _query_ is working through a `console.log({data})` after calling `useQuery`, which should show something like this:
+7. After sending the changes, access a product page and note that the _query_ is working through a `console.log({data})` after calling `useQuery`, which should show something like this:
 
     ```ts
     {
       data: {
         product: {
-         releaseDate: '2019-01-01T00:00:00"',
-         __typename:  "Product"
+          releaseDate: '2019-01-01T00:00:00"',
+          __typename:  "Product"
         }
       }
     }
     ```
 
-6.  To make Countdown set the hours for the product's `releaseDate`, change the `tick` function parameter. You can also remove the `props` received in the component, as they will no longer be used.
+8. At last, but not least, to make Countdown set the hours for the product's `releaseDate`, change the `tick` function parameter. You can also remove the `props` received in the component, as they will no longer be used.
 
     ```diff
     -tick(targetDate, setTime)

--- a/course/steps/08_react-apollo/pt.md
+++ b/course/steps/08_react-apollo/pt.md
@@ -59,10 +59,10 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 4. Feito isso, defina a query usando o `productReleaseDate` importado e o `useQuery`. Os dados de produto podem ser encontrados em `useProduct`. Ambos são [hooks](https://reactjs.org/docs/hooks-intro.html), e portanto, devem ser adicionados dentro de um componente funcional React.
 
     ```diff
-    + const { product: { linkText } } = useProduct()
+    + const { product } = useProduct()
     + const { data, loading, error } = useQuery(productReleaseDate, {
     +   variables: {
-    +     slug: linkText
+    +     slug: product?.linkText
     +   },
     +   ssr: false
     + })
@@ -73,7 +73,7 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 5. Agora que estamos utilizando nosso bloco em páginas que têm contexto de produto, é importante testar se este context existe. Para fazer isso, vamos adicionar o bloco de código abaixo:
 
     ```tsx
-    if (!linkText) {
+    if (!product) {
       return (
         <div>
           <span>There is no product context.</span>

--- a/course/steps/08_react-apollo/pt.md
+++ b/course/steps/08_react-apollo/pt.md
@@ -10,33 +10,38 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 
 - Para implementar esta funcionalidade, precisamos **adicionar o nosso bloco `countdown` na página de produto**, e também faremos nossos testes nessa página também. Para isso, faça o seguinte:
 
-1. Em seu tema clonado (`store-theme`) acesse o arquivo `store/blocks/product.jsonc` e, no bloco `flex-layout.col#right-col` adicione o bloco `countdown`, logo antes do `buy-button`:
-   ```diff
-       "product-gifts",
-   +	"countdown",
-       "flex-layout.row#buy-button",
-       "availability-subscriber",
-   ```
-2. Rode `vtex link` em seu tema novamente (caso o processo já não esteja sendo executado).
-3. Pronto, agora o nosso bloco está na página de produto. Acesse alguma destas páginas e veja o componente `Countdown` renderizado.
+1. Primeiramente, em seu tema clonado (`store-theme`) acesse o arquivo `store/blocks/product.jsonc` e, no bloco `flex-layout.col#right-col` adicione o bloco `countdown`, logo antes do `buy-button`:
+
+    ```diff
+        "product-gifts",
+    +	"countdown",
+        "flex-layout.row#buy-button",
+        "availability-subscriber",
+    ```
+
+2. Rode `vtex link` em seu tema novamente (caso o processo já não esteja sendo executado). Pronto, agora o nosso bloco está na página de produto. Acesse alguma destas páginas e veja o componente `Countdown` renderizado.
 
 ## Query de Release Date
 
-1.  Crie uma pasta `react/queries` e nela adicione um arquivo `productReleaseDate.graphql` que irá conter a _query_ a ser feita. Em particular, essa _query_ irá receber um termo, que será **o slug do produto a ser recuperado a data de lançamento**. Ela chamará o _resolver_ `product`, já disponível pela app `vtex.search-graphql`, e recuperaremos apenas o campo que precisamos.
-    ```
+1. Crie uma pasta `react/queries` e nela adicione um arquivo `productReleaseDate.graphql` que irá conter a _query_ a ser feita. Em particular, essa _query_ irá receber um termo, que será **o slug do produto a ser recuperado a data de lançamento**. Ela chamará o _resolver_ `product`, já disponível pela app `vtex.search-graphql`, e recuperaremos apenas o campo que precisamos.
+
+    ```graphql
     query productReleaseDate($slug: String){
-    	  product(slug: $slug) {
-    		    releaseDate
-    	  }
+        product(slug: $slug) {
+            releaseDate
+        }
     }
     ```
     > Perceba que a query precisará do _slug_ do produto que buscamos. Para isso, **recuperaremos esta informação do contexto de Produto da VTEX**.
-2.  Para utilizar essa query, é necessário **adicionar a app `vtex.search-graphql` como dependência em sua app.** Também precisaremos utilizar o hook `useProduct`, exportado pela app `vtex.product-context`, para recuperar o slug do produto que está carregado na página. Para isso, no `manifest.json` de sua app, adicione em `dependencies`:
+
+2. Para utilizar essa query, é necessário **adicionar a app `vtex.search-graphql` como dependência em sua app.** Também precisaremos utilizar o hook `useProduct`, exportado pela app `vtex.product-context`, para recuperar o slug do produto que está carregado na página. Para isso, no `manifest.json` de sua app, adicione em `dependencies`:
+
     ```
     "vtex.search-graphql": "0.x",
     "vtex.product-context": "0.x"
     ```
-3.  Agora, é necessário importar os hook `useQuery`, para fazer a _query_ que retornará o dado que descrevemos, e `useProduct`, para nos dar a informação sobre o slug do produto atual. Além disso, também é preciso importar a _query_, definida anteriormente, que se encontra no arquivo `productReleaseDate.graphql`. Vale ressaltar também que a *prop* `targetDate` não será mais necessária.
+
+3. Agora, é necessário importar os hook `useQuery`, para fazer a _query_ que retornará o dado que descrevemos, e `useProduct`, para nos dar a informação sobre o slug do produto atual. Além disso, também é preciso importar a _query_, definida anteriormente, que se encontra no arquivo `productReleaseDate.graphql`. Vale ressaltar também que a *prop* `targetDate` não será mais necessária.
 
     ```diff
     // react/Countdown.tsx
@@ -51,7 +56,7 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 
     > É importante notar que há a possibilidade da sua IDE mostrar um erro ao fazer o *import* do `product-context`.
 
-4.  Defina a query usando o `productReleaseDate` importado e o `useQuery`. Os dados de produto podem ser encontrados em `useProduct`. Ambos são (*hooks*)[https://reactjs.org/docs/hooks-intro.html], e portanto, devem ser adicionados dentro de um componente funcional React.
+4. Feito isso, defina a query usando o `productReleaseDate` importado e o `useQuery`. Os dados de produto podem ser encontrados em `useProduct`. Ambos são [hooks](https://reactjs.org/docs/hooks-intro.html), e portanto, devem ser adicionados dentro de um componente funcional React.
 
     ```diff
     + const { product: { linkText } } = useProduct()
@@ -63,10 +68,22 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
     + })
     ```
     
-
     > `linkText` será igual a `'red-analogic-coffee-and-tea-machine'`, por exemplo, quando o seu componente for renderizado na página deste produto.
 
-    Além disso, é preciso tratar os casos de *loading* e *error* antes de retornar o componente principal do contador ao utilizar o *hook* `useQuery`. Para isso, é possível retornar um `span` em cada um dos casos, como no exemplo abaixo, dentro do componente `Countdown`:
+5. Agora que estamos utilizando nosso bloco em páginas que têm contexto de produto, é importante testar se este context existe. Para fazer isso, vamos adicionar o bloco de código abaixo:
+
+    ```tsx
+    if (!linkText) {
+      return (
+        <div>
+          <span>There is no product context.</span>
+        </div>
+      )
+    }
+    ```
+
+6. Além disso, é preciso tratar os casos de *loading* e *error* antes de retornar o componente principal do contador ao utilizar o *hook* `useQuery`. Para isso, é possível retornar um `span` em cada um dos casos, como no exemplo abaixo, dentro do componente `Countdown`:
+
     ```tsx
     if (loading) {
       return (
@@ -82,30 +99,22 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
         </div>
       )
     }
-    if (!product) {
-      return (
-        <div>
-          <span>Não há contexto de produto</span>
-        </div>
-      )
-    }
-
     ```
 
-5.  Após enviar as modificações, acesse uma página de produto e verifique se a _query_ está funcionando através de um `console.log({data})` após a chamada do `useQuery`, que deve mostrar algo como isso:
+7. Após enviar as modificações, acesse uma página de produto e verifique se a _query_ está funcionando através de um `console.log({data})` após a chamada do `useQuery`, que deve mostrar algo como isso:
 
     ```ts
     {
       data: {
         product: {
-         releaseDate: '2019-01-01T00:00:00"',
-         __typename:  "Product"
+          releaseDate: '2019-01-01T00:00:00"',
+          __typename:  "Product"
         }
       }
     }
     ```
 
-6.  Para fazer com que o Countdown marque as horas para o `releaseDate` do produto, mude o parâmetro da função `tick`. Você também pode remover as `props` recebidas no componente, já que não serão mais usadas.
+8. Por fim, para fazer com que o Countdown marque as horas para o `releaseDate` do produto, mude o parâmetro da função `tick`. Você também pode remover as `props` recebidas no componente, já que não serão mais usadas.
     ```diff
     -tick(targetDate, setTime)
     +tick(data?.product?.releaseDate || DEFAULT_TARGET_DATE, setTime)

--- a/course/steps/08_react-apollo/pt.md
+++ b/course/steps/08_react-apollo/pt.md
@@ -41,7 +41,7 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
     "vtex.product-context": "0.x"
     ```
 
-3. Agora, é necessário importar os hook `useQuery`, para fazer a _query_ que retornará o dado que descrevemos, e `useProduct`, para nos dar a informação sobre o slug do produto atual. Além disso, também é preciso importar a _query_, definida anteriormente, que se encontra no arquivo `productReleaseDate.graphql`. Vale ressaltar também que a *prop* `targetDate` não será mais necessária.
+3. Agora, é necessário importar os hook `useQuery`, para fazer a _query_ que retornará o dado que descrevemos, e `useProduct`, para nos dar a informação sobre o slug do produto atual. Além disso, também é preciso importar a _query_, definida anteriormente, que se encontra no arquivo `productReleaseDate.graphql`.
 
     ```diff
     // react/Countdown.tsx
@@ -54,7 +54,9 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
     +import productReleaseDate from './queries/productReleaseDate.graphql'
     ```
 
-    > É importante notar que há a possibilidade da sua IDE mostrar um erro ao fazer o *import* do `product-context`.
+    > É importante notar que há a possibilidade da sua IDE mostrar um erro ao fazer o *import* do `product-context`. 
+    
+    > Vale ressaltar também que tanto a *prop* `targetDate` como a constante `DEFAULT_TARGET_DATE` não serão mais necessárias, então pode pode removê-las e ajustar os _imports_, no caso de não utilizar mais algumas funções.
 
 4. Feito isso, defina a query usando o `productReleaseDate` importado e o `useQuery`. Os dados de produto podem ser encontrados em `useProduct`. Ambos são [hooks](https://reactjs.org/docs/hooks-intro.html), e portanto, devem ser adicionados dentro de um componente funcional React.
 
@@ -117,7 +119,7 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 8. Por fim, para fazer com que o Countdown marque as horas para o `releaseDate` do produto, mude o parâmetro da função `tick`. Você também pode remover as `props` recebidas no componente, já que não serão mais usadas.
     ```diff
     -tick(targetDate, setTime)
-    +tick(data?.product?.releaseDate || DEFAULT_TARGET_DATE, setTime)
+    +tick(data?.product?.releaseDate, setTime)
     ```
 
 Resultado no produto _Red Front-Loading Washer_:

--- a/course/steps/08_react-apollo/pt.md
+++ b/course/steps/08_react-apollo/pt.md
@@ -14,7 +14,7 @@ A biblioteca **Apollo Client** disponibiliza uma integração nativa com React, 
 
     ```diff
         "product-gifts",
-    +	"countdown",
+    +	  "countdown",
         "flex-layout.row#buy-button",
         "availability-subscriber",
     ```

--- a/course/template/react/graphql/productReleaseDate.graphql
+++ b/course/template/react/graphql/productReleaseDate.graphql
@@ -1,5 +1,0 @@
-query productReleaseDate($slug: String){
-  product(slug: $slug) {
-    releaseDate
-  }
-}

--- a/course/template/react/utils/time.ts
+++ b/course/template/react/utils/time.ts
@@ -11,20 +11,20 @@ export const parseTimeRemaining = (totalSeconds: number) : TimeSplit => {
         hours: fillWithZero(2, hours),
         minutes: fillWithZero(2, minutes),
         seconds: fillWithZero(2, seconds)
-    } 
+    }
 }
 
-const fillWithZero = (digits: number, number: number) : string => { 
-   const filled = '0'.repeat(digits - 1) + number 
+const fillWithZero = (digits: number, number: number) : string => {
+   const filled = '0'.repeat(digits - 1) + number
    return filled.slice(filled.length - digits)
 }
 
 /**
- * 
+ *
  * @param targetDate ISOString for the date that the countdown will expire
  * @param dispatchFn A function that updates the state of the component
  */
-export const tick = (targetDate: string, dispatchFn: React.Dispatch<React.SetStateAction<TimeSplit>>) => { 
+export const tick = (targetDate: string, dispatchFn: React.Dispatch<React.SetStateAction<TimeSplit>>) => {
   const ONE_SECOND_IN_MILLIS = 1000
   let finalDate = new Date(targetDate)
   let now = new Date()
@@ -34,4 +34,10 @@ export const tick = (targetDate: string, dispatchFn: React.Dispatch<React.SetSta
   setTimeout(()=> {
     dispatchFn(parseTimeRemaining(secondsLeft))
   }, ONE_SECOND_IN_MILLIS)
+}
+
+export const getTwoDaysFromNow = () => {
+  const today = new Date()
+  today.setDate(today.getDate() + 2)
+  return today.toISOString()
 }


### PR DESCRIPTION
This PR fixes small problems that we identified during last week's training.

- Fixes typos;
- Removes `graphql` folder inside `/react` that is not necessary since the students are supposed to create the file inside `/react/queries` folder;
- Adds new util function to calculate the target date as being two days from now; it avoids to have it mocked on the step;
- Fixes problems with the last step, where the property `linkText` from `product`, when using the `useProduct` query was not accessible because `product` was undefined;
- Removes fallback using the default target date from the last step.